### PR TITLE
Connections Robustness

### DIFF
--- a/mslrb2015/Comms.pde
+++ b/mslrb2015/Comms.pde
@@ -82,6 +82,7 @@ public static void serverEvent(Server whichServer, Client whichClient) {
     } else {
       whichClient.write(COMM_RESET);
       BaseStationServer.disconnect(whichClient);
+      Log.logMessage("ERR Another team connecting");
     }
   }
   if (whichServer.equals(scoreClients.scoreServer))
@@ -107,13 +108,19 @@ public static boolean setteamfromip(String s) {
       println("Team " + row.getString("Team") + " connected (" + row.getString("shortname8") + "/" + row.getString("longame24") + ")");
       teamselect=row;
       
-      if (!TESTMODE && StateMachine.GetCurrentGameState() == GameStateEnum.GS_PREGAME)
-        Popup.show(PopupTypeEnum.POPUP_TEAMSELECTION, "Team: "+row.getString("Team")+"\nSelect color","cyan","magenta");
+      boolean noTeamA = teamA.connectedClient == null || !teamA.connectedClient.active();
+      boolean noTeamB = teamB.connectedClient == null || !teamB.connectedClient.active();
       
-      return true;
+      if (StateMachine.GetCurrentGameState() == GameStateEnum.GS_PREGAME || noTeamA || noTeamB) {
+        Popup.show(PopupTypeEnum.POPUP_TEAMSELECTION, "Team: "+row.getString("Team")+"\nSelect color","cyan","magenta");
+        return true;
+      }else{
+        Log.logMessage("ERR No more connections allowed");
+        return false;
+      }
     }
   }
-  
+  Log.logMessage("ERR Unknown team");
   return false;
 }
 
@@ -133,7 +140,8 @@ public static void checkBasestationsMessages()
       else if(teamB != null && teamB.IPBelongs(thisClient.ip()))
         t=teamB;
       else{
-        println("NON TEAM MESSAGE RECEIVED!!");
+        if(thisClient != connectingClient)
+          println("NON TEAM MESSAGE RECEIVED!!");
         return;
       }
     String whatClientSaid = new String(thisClient.readBytes());

--- a/mslrb2015/RefreshButon.pde
+++ b/mslrb2015/RefreshButon.pde
@@ -83,6 +83,11 @@ void RefreshButonStatus1() {
         
         buttonFromEnum(ButtonsEnum.BTN_START).disable();
         buttonFromEnum(ButtonsEnum.BTN_STOP).activate();
+        
+        if(StateMachine.GetCurrentGameState() == GameStateEnum.GS_OVERTIME)
+        {
+          bCommoncmds[CMDID_COMMON_RESET].enable();
+        }
       }
       
       bCommoncmds[CMDID_COMMON_PARKING].enable();
@@ -141,6 +146,19 @@ void RefreshButonStatus1() {
     for(int i = 0; i < bSlider.length; i++)
       bSlider[i].enable();
   }
+  
+  // Update End Part / End Game button
+  String endPartOrEndGame = "End Part";
+  switch(StateMachine.GetCurrentGameState())
+  {
+  case GS_HALFTIME:
+  case GS_GAMEON_H2: 
+  case GS_GAMEON_H4:
+  case GS_GAMESTOP_H2:
+  case GS_GAMESTOP_H4:
+    endPartOrEndGame = "End Game";
+  }
+  bCommoncmds[CMDID_COMMON_HALFTIME].Label = endPartOrEndGame;
   
 }
 

--- a/mslrb2015/StateMachine.pde
+++ b/mslrb2015/StateMachine.pde
@@ -79,6 +79,7 @@ static class StateMachine
             t.longName=teamselect.getString("longame24");
             t.unicastIP = teamselect.getString("UnicastAddr");
             t.multicastIP = teamselect.getString("MulticastAddr");
+            t.connectedClient = connectingClient;
             connectingClient.write(COMM_WELCOME);
             connectingClient = null;
           }

--- a/mslrb2015/Team.pde
+++ b/mslrb2015/Team.pde
@@ -13,25 +13,15 @@ class Team {
   org.json.JSONObject worldstate_json;
   String wsBuffer;
   Robot[] r=new Robot[5];
- 
-
-  boolean pendingGoal;
   
   File logFile;
   PrintWriter logFileOut;
+  Client connectedClient;
       
   Team(color c, boolean uileftside) {
     this.c=c;
     this.isCyan=uileftside;
-    this.resetname();
-    this.worldstate_json = null;
-    this.wsBuffer = "";
-    logFile = new File((isCyan?"fA_":"fB_") + Log.getTimedName() + ".txt");
-    try{
-      logFileOut = new PrintWriter(new BufferedWriter(new FileWriter(logFile, true)));
-    }catch(IOException e){
-      
-    }
+    
     //robots
     float x=0, y=60; 
     r[0]=new Robot(x, y);
@@ -69,6 +59,8 @@ class Team {
   }
   
   void reset() {
+    this.resetname();
+    
     this.worldstate_json = null;
     this.wsBuffer = "";
     logFile = new File((isCyan?"fA_":"fB_") + Log.getTimedName() + ".txt");
@@ -91,6 +83,7 @@ class Team {
     this.newPenaltyKick=false;
     for (int i=0; i<5; i++)
       r[i].reset();
+    this.connectedClient = null;
   }
 
   void setinfofromtable(Table tab, int id) {
@@ -226,6 +219,14 @@ class Team {
 //*******************************************************************
   
   void updateUI() {
+    if(connectedClient != null && !connectedClient.active())
+    {
+      println("Connection to team \"" + longName + "\" dropped.");
+      BaseStationServer.disconnect(connectedClient);
+      reset();
+    }
+    
+    
     //side border
     rectMode(TOP);
     noStroke();

--- a/mslrb2015/data/config.json
+++ b/mslrb2015/data/config.json
@@ -20,11 +20,11 @@
 		"robotYellowCardColor": "#FEFF0F",
 		"robotDoubleYellowCardColor": "#707000",
 		"robotRedCardColor": "#FF0000",
-		"defaultCyanTeamShortName": "Team A",
-		"defaultCyanTeamLongName": "@LEFT - Cyan",
+		"defaultCyanTeamShortName": "***",
+		"defaultCyanTeamLongName": "Disconnected",
 		"defaultCyanTeamColor": "#007BA7",
-		"defaultMagentaTeamShortName": "Team B",
-		"defaultMagentaTeamLongName": "@Right - Magenta",
+		"defaultMagentaTeamShortName": "***",
+		"defaultMagentaTeamLongName": "Disconnected",
 		"defaultMagentaTeamColor": "#DA70D6"
 	}
 }

--- a/mslrb2015/enums.java
+++ b/mslrb2015/enums.java
@@ -162,7 +162,7 @@ enum GameStateEnum
     "Halftime",
     "2nd Half - STOP",
     "2nd Half",
-    "Overtime",
+    "Pre-Overtime",
     "Overtime - 1st Half - STOP",
     "Overtime - 1st Half", 
     "Overtime - Halftime",


### PR DESCRIPTION
- Detect connection drop
- Allow reconnection during match if connection drops
- Log state messages when errors occur during connection attempts
- Changed default team names in config (disconnected)
- Changed "Overtime" label to "Pre-Overtime"
- Reset is enabled during pre-overtime (match can be over by that time)
- "End part" button shows "End game" on second halves
