### PR TITLE
Minor modifications for Robocup

### DIFF
--- a/mslrb2015/Log.pde
+++ b/mslrb2015/Log.pde
@@ -63,7 +63,8 @@ static class Log
   // Log action to both screen and logfile
   public static void logactions(String c) {
     //year()+month()+hour()+minute()+second()+millis()
-    String s1="["+StateMachine.GetCurrentGameStateString()+"] "+Description.get(c+"");
+    //String s1="["+StateMachine.GetCurrentGameStateString()+"] "+Description.get(c+"");
+    String s1=Description.get(c+"");
     String s2=System.currentTimeMillis()+","+gametime+"("+gameruntime+"),"+StateMachine.GetCurrentGameStateString()+","+c+","+Description.get(c+"");
     lastaction=c;
   

--- a/mslrb2015/LogMerger.pde
+++ b/mslrb2015/LogMerger.pde
@@ -146,7 +146,7 @@ static class LogMerger
 
 // ---
 // Zip all
-  private boolean zipAllFiles()
+  public boolean zipAllFiles()
   {    
     try
     {
@@ -157,7 +157,8 @@ static class LogMerger
       out.setMethod(ZipOutputStream.DEFLATED);
       byte data[] = new byte[BUFFER];
       
-      String[] files = {".msl", ".A.msl", ".B.msl", ".merged.msl"};
+      //String[] files = {".msl", ".A.msl", ".B.msl", ".merged.msl"};
+      String[] files = {".msl", ".A.msl", ".B.msl"};
       for(int i = 0; i < files.length; i++)
       {
         String fileName = mainApplet.dataPath("tmp/" + timedName + files[i]);

--- a/mslrb2015/mslrb2015.pde
+++ b/mslrb2015/mslrb2015.pde
@@ -199,7 +199,10 @@ void draw() {
   textAlign(LEFT, BOTTOM);
   fill(#00ff00);
   for (int i=0; i<5; i++)
+  {
     text( Last5cmds[i], 340, height-4-i*18);
+    fill(#007700);
+  }
   fill(255);
   //server info
   textAlign(CENTER, BOTTOM);
@@ -243,7 +246,8 @@ void exit() {
   if(teamB != null) teamB.reset();
   
   LogMerger merger = new LogMerger(Log.getTimedName());
-  merger.merge();
+  //merger.merge();
+  merger.zipAllFiles();
   
   // Stop all servers
   scoreClients.stopServer();


### PR DESCRIPTION
Remove internal state machine information from log messages
Highlight last command in log messages
Don't merge worldstate information from teams (to prevent java heap problem in windows)
