### PR TITLE
Replace no-break space by a regular space

### DIFF
--- a/mslrb2015/SystemEvents.pde
+++ b/mslrb2015/SystemEvents.pde
@@ -6,7 +6,7 @@ void mousePressed() {
     int pos = -1;
     
     for (int i=0; i<4; i++)
-      if (bSlider[i].mouseover()) { bSlider[i].toogle(); refreshslider=true; pos=i; break;}    
+      if (bSlider[i].mouseover()) { bSlider[i].toogle(); refreshslider=true; pos=i; break;}
     if (refreshslider) {
       
     setbooleansfrombsliders();


### PR DESCRIPTION
The refbox was not able to run: `processing.app.SketchException: Not expecting symbol 0xA0, which is NO-BREAK SPACE.`
This fixes this problem