### PR TITLE
Communicate when end-of-game penalties start

### DIFF
--- a/RefereeClient/Comms.pde
+++ b/RefereeClient/Comms.pde
@@ -51,6 +51,7 @@ public static final char COMM_FIRST_HALF = '1';
 public static final char COMM_SECOND_HALF = '2';
 public static final char COMM_FIRST_HALF_OVERTIME = '3';  //NEW 2015CAMBADA: 
 public static final char COMM_SECOND_HALF_OVERTIME = '4';  //NEW 2015CAMBADA: 
+public static final char COMM_END_OF_GAME_PENALTIES = '5';
 public static final char COMM_HALF_TIME = 'h';
 public static final char COMM_END_GAME = 'e';    //ends 2nd part, may go into overtime
 public static final char COMM_GAMEOVER = 'z';  //NEW 2015CAMBADA: Game Over
@@ -106,6 +107,7 @@ void comms_initDescriptionDictionary() {
   Description.set("2", "2nd half");
   Description.set("3", "Overtime 1st half");  //NEW 2015CAMBADA
   Description.set("4", "Overtime 2nd half");  //NEW 2015CAMBADA
+  Description.set("5", "End of Game Penalties");
   Description.set("L", "Park");
   
   Description.set("K", "Kick Off CYAN");

--- a/mslrb2015/Comms.pde
+++ b/mslrb2015/Comms.pde
@@ -342,6 +342,7 @@ public static final char COMM_FIRST_HALF = '1';
 public static final char COMM_SECOND_HALF = '2';
 public static final char COMM_FIRST_HALF_OVERTIME = '3';  //NEW 2015CAMBADA: 
 public static final char COMM_SECOND_HALF_OVERTIME = '4';  //NEW 2015CAMBADA: 
+public static final char COMM_END_OF_GAME_PENALTIES = '5';
 public static final char COMM_HALF_TIME = 'h';
 public static final char COMM_END_GAME = 'e';    //ends 2nd part, may go into overtime
 public static final char COMM_GAMEOVER = 'z';  //NEW 2015CAMBADA: Game Over
@@ -392,6 +393,7 @@ void comms_initDescriptionDictionary() {
   Description.set("2", "2nd half");
   Description.set("3", "Overtime 1st half");
   Description.set("4", "Overtime 2nd half");
+  Description.set("5", "End of Game Penalties");
   Description.set("L", "Park");
   
   Description.set("K", "CYAN Kickoff");

--- a/mslrb2015/StateMachine.pde
+++ b/mslrb2015/StateMachine.pde
@@ -1,6 +1,5 @@
 static class StateMachine
 {
-  
   private static boolean needUpdate = false; 
   private static boolean btnOn = false;
   private static ButtonsEnum btnCurrent = ButtonsEnum.BTN_ILLEGAL;
@@ -13,8 +12,7 @@ static class StateMachine
   public static ButtonsEnum setpiece_button = null;
   
   public static boolean firstKickoffCyan = true;
-
-  
+  private static boolean startedEndOfGamePenalties = false;
   
   public static void Update(ButtonsEnum click_btn, boolean on)
   {
@@ -56,10 +54,11 @@ static class StateMachine
             gsCurrent = SwitchGamePart();
             gsPrev = saveGS;
             resetStartTime(false);
+            
             if (bCommoncmds[CMDID_COMMON_HALFTIME].Label.equals("End Game"))
               send_event_v2(cCommcmds[CMDID_COMMON_ENDGAME], Commcmds[CMDID_COMMON_ENDGAME], null);
             else
-              send_event_v2(cCommcmds[CMDID_COMMON_HALFTIME], Commcmds[CMDID_COMMON_HALFTIME], null);            
+              send_event_v2(cCommcmds[CMDID_COMMON_HALFTIME], Commcmds[CMDID_COMMON_HALFTIME], null);
           }
           break;
         }
@@ -138,6 +137,7 @@ static class StateMachine
           t.newYellowCard = btnOn;
       }
       
+      /* Update game state */
       switch(gsCurrent)
       {
         // PRE-GAME and Half Times
@@ -182,14 +182,14 @@ static class StateMachine
         case GS_GAMESTOP_H4:
           if(btnCurrent.isSetPiece())
             SetSetpiece(btnCurrent.isCyan(), btnCurrent);
-          else if(btnCurrent.isStart()){
+          else if(btnCurrent.isStart())
             nextGS = SwitchRunningStopped();
-          }
           else if(btnCurrent.isStop())
             ResetSetpiece();
           else if(btnCurrent.isEndPart())
             nextGS = SwitchGamePart();
           
+
           break;
         
         case GS_GAMEON_H1:
@@ -207,6 +207,10 @@ static class StateMachine
           break;
           
         case GS_PENALTIES:
+          if(!startedEndOfGamePenalties){
+            send_to_basestation(COMM_END_OF_GAME_PENALTIES + "");
+            startedEndOfGamePenalties = true;
+          }
           if(btnCurrent.isSetPiece())                        // Kick Off either, Penalty either, DropBall
             SetSetpiece(btnCurrent.isCyan(), btnCurrent);
           else if(btnCurrent.isStop())
@@ -215,7 +219,6 @@ static class StateMachine
             nextGS = SwitchGamePart();
           else if(btnCurrent.isStart())
             nextGS = SwitchRunningStopped();
-            
           break;
         
         case GS_PENALTIES_ON:
@@ -335,6 +338,7 @@ static class StateMachine
       send_to_basestation("" + COMM_RESET);
       
       needUpdate = false; 
+      startedEndOfGamePenalties = false;
       btnCurrent = ButtonsEnum.BTN_ILLEGAL;
       btnPrev = ButtonsEnum.BTN_ILLEGAL;
       gsCurrent = GameStateEnum.GS_PREGAME;

--- a/mslrb2015/enums.java
+++ b/mslrb2015/enums.java
@@ -200,4 +200,3 @@ enum PopupTypeEnum
       return value;
   }
 };
-


### PR DESCRIPTION
A `5` will be communicated on the first start signal of the end-of-game penalties.
Fixes #32. When accepted, `5` should be added to the communicated signals on the wiki.