### PR TITLE
Repair timer per robot

### DIFF
--- a/mslrb2015/Robot.pde
+++ b/mslrb2015/Robot.pde
@@ -3,9 +3,7 @@
 class Robot {
   float guix, guiy;
   String state="play"; //play , repair , yellow, doubleyellow , red
-  int waittime=-1;
-  long DoubleYellowOut=0; 
-  long DoubleYellowOutRemain=0; 
+  long outTime = 0; // Time at which this robot left the field
 
   Robot(float zx, float zy) {
     guix=zx; 
@@ -13,24 +11,9 @@ class Robot {
   }
 
 //-------------------------------
-  void reset_to_play() {
-    state="play";
-    waittime=-1;
-  }
-  
-//-------------------------------
   void reset() {
     state="play";
-    waittime=-1;
-    this.DoubleYellowOut=0;
-    this.DoubleYellowOutRemain=0; 
-  }
-  
-//-------------------------------
-  void setRstate(Robot r) {
-    this.state=r.state;
-    this.waittime=r.waittime;
-    this.DoubleYellowOut=r.DoubleYellowOut;
+    outTime=0;
   }
   
 //-------------------------------
@@ -49,7 +32,14 @@ class Robot {
     if (UIleft) tx=offsetLeft.x - 165 + this.guix;       
     ellipse(tx, ty, 42, 42);  
     fill(255);
-    if (waittime>=0)  text(nf(waittime+1, 2), tx, ty);
+    
+    /* Repair */
+    int waitTime = (int)(this.outTime+Config.repairPenalty_ms - getSplitTime())/1000;
+    if (waitTime >= 0 && state.equals("repair")) text(nf(waitTime+1, 2), tx, ty);
+    
+    /* Double Yellow */
+    waitTime = (int)(this.outTime + Config.doubleYellowPenalty_ms - getSplitTime())/1000;
+    if (waitTime >= 0 && state.equals("doubleyellow")) text(nf(waitTime+1, 2), tx, ty);
   }
   
 }

--- a/mslrb2015/ScoreClients.pde
+++ b/mslrb2015/ScoreClients.pde
@@ -61,9 +61,11 @@ class ScoreClients
     
     for(int i = 0; i < 5; i++){
       teamA_robotState += "\"" + teamA.r[i].state + "\"" + ((i==4)?"":",");
-      teamA_robotWaitTime += teamA.r[i].waittime + ((i==4)?"":",");
+      long waitTime = teamA.r[i].outTime - getSplitTime() + Config.repairPenalty_ms;
+      teamA_robotWaitTime += waitTime + ((i==4)?"":",");
       teamB_robotState += "\"" + teamB.r[i].state + "\"" + ((i==4)?"":",");
-      teamB_robotWaitTime += teamB.r[i].waittime + ((i==4)?"":",");
+      waitTime = teamB.r[i].outTime - getSplitTime() + Config.repairPenalty_ms;
+      teamB_robotWaitTime += waitTime + ((i==4)?"":",");
     }
     
     String msg = "{";

--- a/mslrb2015/data/config.json
+++ b/mslrb2015/data/config.json
@@ -16,7 +16,7 @@
 	"rules":
 	{
 		"repairPenalty_ms": 20000,
-		"doubleYellowPenalty_ms": 120000,
+		"doubleYellowPenalty_ms": 90000,
 		"setPieceMaxTime_ms": 7000
 	},
 	"appearance":

--- a/mslrb2015/data/config.json
+++ b/mslrb2015/data/config.json
@@ -15,7 +15,7 @@
 	},
 	"rules":
 	{
-		"repairPenalty_ms": 30000,
+		"repairPenalty_ms": 20000,
 		"doubleYellowPenalty_ms": 120000,
 		"setPieceMaxTime_ms": 7000
 	},


### PR DESCRIPTION
Set a separate timer per robot that is taken out of the field for repair as required by the new rules for this year. Some cleanup was also done to streamline behaviour between different cards and repair.
Also double yellow (2017) and repair (2019) penalty times were updated.

This fixes #30.