### PR TITLE
teams: fix wrong targetTeam for second connection when same team connects twice

### DIFF
--- a/mslrb2015/Team.pde
+++ b/mslrb2015/Team.pde
@@ -114,9 +114,21 @@ class Team {
 		unicastIP = teamselect.getString("UnicastAddr");
 		multicastIP = teamselect.getString("MulticastAddr");
 
+		String teamID = isLeft ? "A" : "B";
+
+		// support same team connecting twice: newest team gets adapted ids
+		if(teamA.team == teamB.team)
+		{
+			team 	 += " " + teamID;
+			longName += " " + teamID;
+		}
+		if(teamA.multicastIP == teamB.multicastIP)
+		{
+			multicastIP += ":1";
+		}
 
 		if(connectedClient != null)
-		BaseStationServer.disconnect(connectedClient);
+			BaseStationServer.disconnect(connectedClient);
 
 		connectedClient = connectingClient;
 		send_event_v2(COMM_WELCOME,COMM_WELCOME, this ,-1);
@@ -124,7 +136,7 @@ class Team {
 
 		if(this.logFile == null || this.logFileOut == null)
 		{
-			this.logFile = new File(mainApplet.dataPath("tmp/" + Log.getTimedName() + "." + (isLeft?"A":"B") + ".msl"));
+			this.logFile = new File(mainApplet.dataPath("tmp/" + Log.getTimedName() + "." + (teamID) + ".msl"));
 			try{
 				this.logFileOut = new PrintWriter(new BufferedWriter(new FileWriter(logFile, true)));
 			}catch(IOException e){ }

--- a/mslrb2015/mslrb2015.pde
+++ b/mslrb2015/mslrb2015.pde
@@ -247,18 +247,6 @@ void draw() {
 		bTeamBcmds[i].update();
 	}
 
-	//Special case: what if the same team connects twice to RefBox
-	if(teamA.team == teamB.team)
-	{
-		teamA.team =  teamA.team +" A";
-		teamA.longName = teamA.longName+" A";
-		teamA.multicastIP += ":1";
-	}
-	if(teamA.multicastIP == teamB.multicastIP)
-	{
-		teamA.multicastIP += ":1";
-	}
-
 	teamA.updateUI();
 	teamB.updateUI();
 


### PR DESCRIPTION
Problem: When a team connects twice to the refbox from the same IP the refbox sends both WELCOME messages with the same IP.
Cause: the id of the teams is made unique too late, at show of the refbox
Solution: Ensure unique ids (including the IP) before WELCOME message is sent.